### PR TITLE
3826 Add check for null as well as undefined

### DIFF
--- a/public/app/uuid/uuid.controller.js
+++ b/public/app/uuid/uuid.controller.js
@@ -27,7 +27,7 @@
                     $scope.errorMsg = "";
                         var url = discover.uuidHost;
                         var posturl = '';
-                        if ($scope.uuidCount === undefined){
+                        if (($scope.uuidCount === undefined) || ($scope.uuidCount === null)){
                             posturl = "/proxy?url="+ url +"/v1/uuids"
                         }
                         else {


### PR DESCRIPTION
Realized that if you enter a number and then delete it, submitting the form sends a null value instead of undefined.  That causes a bad request error, so checking for both fixes that problem